### PR TITLE
CASMUSER-2790: Use the COS provided boot parameters rpm

### DIFF
--- a/ansible/roles/uan_packages/defaults/main.yml
+++ b/ansible/roles/uan_packages/defaults/main.yml
@@ -14,12 +14,10 @@ uan_sles15_repositories_add:
 
 uan_sles15_packages_remove:
   - cray-cos-release
-  - cray-boot-parameters-shasta-compute
 uan_sles15_packages_add:
   - cfs-trust
   - cray-diags-fabric
   - cray-switchboard
-  - cray-uan-boot-parameters-shasta-uan
   - cray-uan-diagnostics
   - cray-uan-goss
   - cray-uan-load-drivers-shasta-uan


### PR DESCRIPTION
UAN should start with the default kernel parameters that COS maintains now that UAN is being driven by the COS recipe (and UAN CFS plays).

Any changes in kernel parameters that UAN requires or modifies from the COS defaults, may be set in the BOS session template.

Here's the difference between the uan kernel parameters from the rpm and the cos kernel parameters:
```
$ diff uan_kernel.txt cos_kernel.txt
4c4
< crashkernel=340M
---
> crashkernel=360M
6d5
< ifmap=net2:nmn0,lan0:hsn0,lan1:hsn1
10d8
< ip=nmn0:dhcp
12d9
< numa_zonelist_order=node
16,17d12
< printk.synchronous=y
< quiet
```

The difference between what we document admins put in their BOS session template (overrides the parameters from the rpm):
```
$ diff uan_kernel.txt cos_kernel.txt
4c4
< crashkernel=340M
---
> crashkernel=360M
6d5
< ifmap=net2:nmn0,lan0:hsn0,lan1:hsn1
10d8
< ip=nmn0:dhcp
12d9
< numa_zonelist_order=node
16,17d12
< printk.synchronous=y
< quiet
```