### PR TITLE
CASMUSER-2832: Remove unneeded packages

### DIFF
--- a/ansible/roles/uan_packages/defaults/main.yml
+++ b/ansible/roles/uan_packages/defaults/main.yml
@@ -15,9 +15,7 @@ uan_sles15_repositories_add:
 uan_sles15_packages_remove:
   - cray-cos-release
 uan_sles15_packages_add:
-  - cfs-trust
   - cray-diags-fabric
-  - cray-switchboard
   - cray-uan-diagnostics
   - cray-uan-goss
   - cray-uan-load-drivers-shasta-uan


### PR DESCRIPTION
Switchboard should only be used via the UAS Broker model. 

cfs-trust is already required by cfs-state-reporter:
```
uan01:~ # rpm -q --whatrequires cfs-trust
cfs-state-reporter-1.4.6-20210128142235_6bb340b.x86_64
```