### PR TITLE
Add filter_plugins for k3s support plus customer_routes fix

### DIFF
--- a/ansible/filter_plugins/duplicates.py
+++ b/ansible/filter_plugins/duplicates.py
@@ -1,0 +1,18 @@
+#!/usr/bin/python
+
+class FilterModule(object):
+    def filters(self):
+        return {'duplicates': self.duplicates}
+
+    def duplicates(self, items):
+        sums = {}
+        result = []
+
+        for item in items:
+            if item not in sums:
+                sums[item] = 1
+            else:
+                if sums[item] == 1:
+                    result.append(item)
+                sums[item] += 1
+        return result

--- a/ansible/roles/uan_interfaces/tasks/customer_interfaces.yml
+++ b/ansible/roles/uan_interfaces/tasks/customer_interfaces.yml
@@ -104,7 +104,7 @@
     changed_when: result.rc == 0
     failed_when: result.rc != 0
     register: result
-    when: (uan_customer_default_route | bool) or (customer_uan_interfaces | length)
+    when: (uan_customer_default_route | bool) or (customer_uan_interfaces | length) or (customer_uan_routes | length)
 
   - name: Wait 5 seconds for wickedd-nanny to restart
     wait_for:
@@ -122,7 +122,7 @@
     changed_when: result.rc == 0
     failed_when: result.rc != 0
     register: result
-    when: (uan_customer_default_route | bool) or (customer_uan_interfaces | length)
+    when: (uan_customer_default_route | bool) or (customer_uan_interfaces | length) or (customer_uan_routes | length)
 
   - name: Wait 10 seconds for the interfaces to come up
     wait_for:


### PR DESCRIPTION
## Summary and Scope

This PR is to resolve a missing Ansible plugin required for k3s.yml in the UAN 2.5 release.  It also resolves an end case where wicked and wicked-nanny were not being reloaded/restarted if only a customer route was added.  This end case is hit when CAN/CHN is not used and the default route needs to be placed on an existing interface such as nmn0.  This was the case on groot.

Testing on groot was successful.

