### PR TITLE
Alert that UAN has moved to USS

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # User Access Nodes
 
+NOTE: User Access Nodes are now part of the User Services Software in USS-1.1.0. This repository is no longer maintained.
+
 This repository contains the following components for the Shasta User Access Nodes:
 
   1. Pre- and post-boot Ansible configuration (located in ansible/)

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # User Access Nodes
 
-NOTE: User Access Nodes are now part of the User Services Software in USS-1.1.0. This repository is no longer maintained.
+NOTE: User Access Nodes are now part of HPE Cray User Services Software (USS) beginning with the 1.1.0 release. This repository is no longer maintained.
 
 This repository contains the following components for the Shasta User Access Nodes:
 


### PR DESCRIPTION
## Summary and Scope

This PR adds an alert on the README that UAN has moved to USS in USS 1.1.0. There is an accompanying PR for the Cray-HPE/uan-product-stream repository.

This PR must not be merged until after the PR that moves UAN to USS. 
https://github.hpe.com/hpe/hpc-shasta-os-uss-product-stream/pull/29

## Issues and Related PRs

* Resolves [CASMUSER-3280](https://jira-pro.it.hpe.com:8443/browse/CASMUSER-3280) for uan